### PR TITLE
Add all schema definitions, not only value

### DIFF
--- a/modules/editable_view_mode/editable_view_mode.module
+++ b/modules/editable_view_mode/editable_view_mode.module
@@ -40,7 +40,7 @@ function editable_view_mode_entity_view_alter(&$build, EntityInterface $entity, 
       }
       if (method_exists($field, 'getSchema')) {
         $schema = $field->getSchema();
-        $fieldDefinition['schema'] = $schema['columns']['value'];
+        $fieldDefinition['schema'] = $schema['columns'];
       }
       $serialized_fields[$field->getName()] = $fieldDefinition;
     }


### PR DESCRIPTION
Not all fields have the property 'value' in field definitions and also they might have other properties, so add them all instead of limiting to 'value' that might not exist.