### PR TITLE
Feature/editable address

### DIFF
--- a/modules/editable_view_mode/editable_view_mode.module
+++ b/modules/editable_view_mode/editable_view_mode.module
@@ -103,6 +103,8 @@ function _editable_view_mode_get_field_definitions($entity_type, $bundle) {
       }
     }
     $fieldDefinition = _editable_view_mode_sanitize_field_definition($fieldDefinition);
+    // Allow other modules to alter the field definition.
+    \Drupal::moduleHandler()->alter('editable_field_definition', $fieldDefinition);
     $serialized_fields[$field->getName()] = $fieldDefinition;
   }
   return $serialized_fields;

--- a/modules/editable_view_mode/modules/editable_address/editable_address.info.yml
+++ b/modules/editable_view_mode/modules/editable_address/editable_address.info.yml
@@ -1,0 +1,8 @@
+name: Editable Address
+type: module
+description: "Provides additional functionality to support address element"
+package: Editable
+core: 8.x
+dependencies:
+  - editable_view_mode:editable_view_mode
+  - address:address

--- a/modules/editable_view_mode/modules/editable_address/editable_address.module
+++ b/modules/editable_view_mode/modules/editable_address/editable_address.module
@@ -7,6 +7,8 @@
 
 use CommerceGuys\Addressing\AddressFormat\AddressFormatHelper;
 use CommerceGuys\Addressing\AddressFormat\FieldOverrides;
+use CommerceGuys\Addressing\Subdivision\PatternType;
+use CommerceGuys\Addressing\Subdivision\SubdivisionRepository;
 use Drupal\address\FieldHelper;
 use Drupal\address\LabelHelper;
 use CommerceGuys\Addressing\Locale;
@@ -16,14 +18,19 @@ use CommerceGuys\Addressing\Locale;
  */
 function editable_address_editable_field_definition_alter(&$field_definition) {
   if (!empty($field_definition['field_type']) && $field_definition['field_type'] == 'address') {
+    $locale = \Drupal::languageManager()->getConfigOverrideLanguage()->getId();
     $available_countries = $field_definition['settings']['available_countries'];
+    if (empty($available_countries)) {
+      $available_countries_defintions = \Drupal::service('address.country_repository')->getList($locale);
+      $available_countries = array_keys($available_countries_defintions);
+      $field_definition['settings']['available_countries'] = $available_countries;
+    }
     foreach ($available_countries as $available_country) {
       $field_overrides = new FieldOverrides($field_definition['settings']['field_overrides']);
       /** @var \CommerceGuys\Addressing\AddressFormat\AddressFormat $address_format */
       $address_format = \Drupal::service('address.address_format_repository')->get($available_country);
       $required_fields = AddressFormatHelper::getRequiredFields($address_format, $field_overrides);
       $labels = LabelHelper::getFieldLabels($address_format);
-      $locale = \Drupal::languageManager()->getConfigOverrideLanguage()->getId();
       if (Locale::matchCandidates($address_format->getLocale(), $locale)) {
         $format_string = $address_format->getLocalFormat();
       }
@@ -43,23 +50,44 @@ function editable_address_editable_field_definition_alter(&$field_definition) {
       }
       // Load and insert the subdivisions for each parent id.
       $locale = \Drupal::languageManager()->getConfigOverrideLanguage()->getId();
+      $subdivisions_list = [];
       $subdivisions = [];
       $parents = [$available_country];
       foreach ($subdivision_properties as $index => $property) {
         $result = \Drupal::service('address.subdivision_repository')
           ->getList($parents, $locale);
         if ($result) {
-          $subdivisions[$property] = $result;
-          _editable_address_subdivision($subdivisions[$property], $parents, $locale, $subdivision_properties, $index);
+          $subdivisions_list[$property] = $result;
+          _editable_address_subdivision($subdivisions_list[$property], $subdivisions, $parents, $locale, $subdivision_properties, $index);
         }
         break;
+      }
+      // Resolve the available postal code patterns for validation.
+      $fullPattern = $address_format->getPostalCodePattern();
+      $startPatterns = [];
+      /** @var \CommerceGuys\Addressing\Subdivision\Subdivision $subdivision */
+      foreach ($subdivisions as $subdivision) {
+        $pattern = $subdivision->getPostalCodePattern();
+        if (empty($pattern)) {
+          continue;
+        }
+
+        if ($subdivision->getPostalCodePatternType() == PatternType::START) {
+          $startPatterns[$subdivision->getCode()] = $pattern;
+        }
       }
       $field_definition['settings']['country_formats'][$available_country] = [
         'required_fields' => $required_fields,
         'labels' => $labels,
         'grouped_fields' => $grouped_fields,
         'used_fields' => $used_fields,
-        'subdivisions' => $subdivisions,
+        'subdivisions' => $subdivisions_list,
+        'validation' => [
+          'postal_code' => [
+            'pattern' => $fullPattern,
+            'by_subdivision' => $startPatterns,
+          ],
+        ],
       ];
     }
   }
@@ -74,19 +102,21 @@ function editable_address_editable_field_definition_alter(&$field_definition) {
  * @param $subdivision_properties
  * @param $index
  */
-function _editable_address_subdivision(&$subdivisions, $parents, $locale, $subdivision_properties, $index) {
+function _editable_address_subdivision(&$subdivisions, &$objects, $parents, $locale, $subdivision_properties, $index) {
   if (!isset($subdivision_properties[$index + 1])) {
     return;
   }
+  $subdivisions_repository = new SubdivisionRepository();
   foreach ($subdivisions as $key => $value) {
     $index_parents = $parents;
+    $objects[] = $subdivisions_repository->get($key, $parents);
     $index_parents[] = $value;
     $result = \Drupal::service('address.subdivision_repository')
       ->getList($index_parents, $locale);
     if (!empty($result)) {
       $index++;
       $subdivisions[$subdivision_properties[$index]] = $result;
-      _editable_address_subdivision($subdivisions[$subdivision_properties[$index]], $index_parents, $locale, $subdivision_properties, $index);
+      _editable_address_subdivision($subdivisions[$subdivision_properties[$index]], $objects, $index_parents, $locale, $subdivision_properties, $index);
     }
   }
 }

--- a/modules/editable_view_mode/modules/editable_address/editable_address.module
+++ b/modules/editable_view_mode/modules/editable_address/editable_address.module
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * @file
+ * Contains functions for editable to support address fields.
+ */
+
+use CommerceGuys\Addressing\AddressFormat\AddressFormatHelper;
+use CommerceGuys\Addressing\AddressFormat\FieldOverrides;
+use Drupal\address\FieldHelper;
+use Drupal\address\LabelHelper;
+use CommerceGuys\Addressing\Locale;
+
+/**
+ * Implements hook_editable_field_definition_alter().
+ */
+function editable_address_editable_field_definition_alter(&$field_definition) {
+  if (!empty($field_definition['field_type']) && $field_definition['field_type'] == 'address') {
+    $available_countries = $field_definition['settings']['available_countries'];
+    foreach ($available_countries as $available_country) {
+      $field_overrides = new FieldOverrides($field_definition['settings']['field_overrides']);
+      /** @var \CommerceGuys\Addressing\AddressFormat\AddressFormat $address_format */
+      $address_format = \Drupal::service('address.address_format_repository')->get($available_country);
+      $required_fields = AddressFormatHelper::getRequiredFields($address_format, $field_overrides);
+      $labels = LabelHelper::getFieldLabels($address_format);
+      $locale = \Drupal::languageManager()->getConfigOverrideLanguage()->getId();
+      if (Locale::matchCandidates($address_format->getLocale(), $locale)) {
+        $format_string = $address_format->getLocalFormat();
+      }
+      else {
+        $format_string = $address_format->getFormat();
+      }
+      $grouped_fields = AddressFormatHelper::getGroupedFields($format_string, $field_overrides);
+      $used_fields = [];
+      foreach ($grouped_fields as $group => $fields) {
+        foreach ($fields as $field) {
+          $used_fields[] = $field;
+        }
+      }
+      $subdivision_properties = [];
+      foreach ($address_format->getUsedSubdivisionFields() as $field) {
+        $subdivision_properties[] = FieldHelper::getPropertyName($field);
+      }
+      // Load and insert the subdivisions for each parent id.
+      $locale = \Drupal::languageManager()->getConfigOverrideLanguage()->getId();
+      $subdivisions = [];
+      $parents = [$available_country];
+      foreach ($subdivision_properties as $index => $property) {
+        $result = \Drupal::service('address.subdivision_repository')
+          ->getList($parents, $locale);
+        if ($result) {
+          $subdivisions[$property] = $result;
+          _editable_address_subdivision($subdivisions[$property], $parents, $locale, $subdivision_properties, $index);
+        }
+        break;
+      }
+      $field_definition['settings']['country_formats'][$available_country] = [
+        'required_fields' => $required_fields,
+        'labels' => $labels,
+        'grouped_fields' => $grouped_fields,
+        'used_fields' => $used_fields,
+        'subdivisions' => $subdivisions,
+      ];
+    }
+  }
+}
+
+/**
+ * Recursive subdivisions.
+ *
+ * @param $subdivisions
+ * @param $parents
+ * @param $locale
+ * @param $subdivision_properties
+ * @param $index
+ */
+function _editable_address_subdivision(&$subdivisions, $parents, $locale, $subdivision_properties, $index) {
+  if (!isset($subdivision_properties[$index + 1])) {
+    return;
+  }
+  foreach ($subdivisions as $key => $value) {
+    $index_parents = $parents;
+    $index_parents[] = $value;
+    $result = \Drupal::service('address.subdivision_repository')
+      ->getList($index_parents, $locale);
+    if (!empty($result)) {
+      $index++;
+      $subdivisions[$subdivision_properties[$index]] = $result;
+      _editable_address_subdivision($subdivisions[$subdivision_properties[$index]], $index_parents, $locale, $subdivision_properties, $index);
+    }
+  }
+}


### PR DESCRIPTION
Added the alter hook in editable_view_mode to allow other modules to add field type specific settings.
Added editable_address module that enriches the field type address with the information about address formats and validation of postal codes.